### PR TITLE
[codex] Use chat IDs in navigation routes

### DIFF
--- a/firusya-app/Features/Chats/Views/ChatNavHost.swift
+++ b/firusya-app/Features/Chats/Views/ChatNavHost.swift
@@ -17,13 +17,79 @@ struct ChatNavHost: View {
             ChatsView()
                 .navigationDestination(for: ChatsRoute.self) { route in
                     switch route {
-                    case .chat(chat: let chat):
-                        ChatView(chat: chat)
+                    case .chat(id: let chatID):
+                        ChatDestinationView(chatID: chatID)
                         
-                    case .chatInfo(chat: let chat):
-                        Text("Chat info \(chat.contact.displayName)")
+                    case .chatInfo(id: let chatID):
+                        ChatInfoDestinationView(chatID: chatID)
                     }
                 }
+        }
+    }
+}
+
+private struct ChatDestinationView: View {
+    let chatID: UUID
+
+    @Environment(\.modelContext) private var modelContext
+    @State private var chat: Chat?
+
+    var body: some View {
+        Group {
+            if let chat {
+                ChatView(chat: chat)
+            } else {
+                ContentUnavailableView("Chat not found", systemImage: "bubble.left.and.bubble.right")
+            }
+        }
+        .task(id: chatID) {
+            loadChat()
+        }
+    }
+}
+
+private extension ChatDestinationView {
+    func loadChat() {
+        let repository = ChatsRepository(modelContext: modelContext)
+
+        do {
+            chat = try repository.fetchChat(id: chatID)
+        } catch {
+            assertionFailure("Failed to fetch chat: \(error)")
+            chat = nil
+        }
+    }
+}
+
+private struct ChatInfoDestinationView: View {
+    let chatID: UUID
+
+    @Environment(\.modelContext) private var modelContext
+    @State private var chat: Chat?
+
+    var body: some View {
+        Group {
+            if let chat {
+                Text("Chat info \(chat.contact.displayName)")
+            } else {
+                ContentUnavailableView("Chat not found", systemImage: "info.circle")
+            }
+        }
+        .task(id: chatID) {
+            loadChat()
+        }
+    }
+}
+
+private extension ChatInfoDestinationView {
+    func loadChat() {
+        let repository = ChatsRepository(modelContext: modelContext)
+
+        do {
+            chat = try repository.fetchChat(id: chatID)
+        } catch {
+            assertionFailure("Failed to fetch chat info: \(error)")
+            chat = nil
         }
     }
 }

--- a/firusya-app/Root/Router.swift
+++ b/firusya-app/Root/Router.swift
@@ -29,11 +29,11 @@ import SwiftUI
 extension Router {
     func openChat(_ chat: Chat) {
         selectedTab = .chats
-        chatsPath.append(ChatsRoute.chat(chat: chat))
+        chatsPath.append(ChatsRoute.chat(id: chat.id))
     }
     
     func openChatInfo(_ chat: Chat) {
-        chatsPath.append(ChatsRoute.chatInfo(chat: chat))
+        chatsPath.append(ChatsRoute.chatInfo(id: chat.id))
     }
     
     func openContact(_ contactId: UUID) {
@@ -69,8 +69,8 @@ enum AppTab: Hashable {
 }
 
 enum ChatsRoute: Hashable {
-    case chat(chat: Chat)
-    case chatInfo(chat: Chat)
+    case chat(id: UUID)
+    case chatInfo(id: UUID)
 }
 
 enum ContactsRoute: Hashable {


### PR DESCRIPTION
## What changed
- switched `ChatsRoute` to store `UUID` values instead of `Chat` model instances
- updated chat navigation pushes to append route IDs rather than SwiftData models
- resolved chat destinations inside `ChatNavHost` by loading the model from `ChatsRepository`
- added a simple unavailable fallback if a chat can no longer be found

## Why
This aligns the navigation path with Apple's guidance for `NavigationStack` and `NavigationPath`: the path now describes lightweight route state instead of carrying full model objects.

## Impact
- chat navigation remains behaviorally the same for users
- the navigation state is safer to persist, reconstruct, and reason about
- the routing layer is less tightly coupled to live SwiftData model instances

## Validation
- built successfully with `xcodebuild -project firusya-app.xcodeproj -scheme firusya-app -destination 'generic/platform=iOS Simulator' -derivedDataPath /tmp/firusya-derived build`

## Notes
- left the unrelated local change in `firusya-app/Resources/Localizable.xcstrings` out of this branch's commit